### PR TITLE
Fix bug when specifying a private IP

### DIFF
--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -74,7 +74,7 @@ module AmiSpec
         ServerSpec.run(
           instance: ec2,
           spec: specs,
-          private_ip: options[:aws_public_ip],
+          public_ip: options[:aws_public_ip],
           user: ssh_user,
           key_file: key_file,
           debug: debug,

--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -11,10 +11,10 @@ module AmiSpec
 
     def initialize(options)
       instance = options.fetch(:instance)
-      private_ip = options.fetch(:private_ip, true)
+      public_ip = options.fetch(:public_ip, true)
 
       @debug = options.fetch(:debug)
-      @ip = private_ip ? instance.private_ip_address : instance.public_ip_address
+      @ip = public_ip ? instance.public_ip_address : instance.private_ip_address
       @role = instance.tags.find{ |tag| tag.key == 'AmiSpec' }.value
       @spec = options.fetch(:spec)
       @user = options.fetch(:user)


### PR DESCRIPTION
The reverse logic now applies, we specify when we want a public IP not
when we want a private one
