### PR TITLE
Why you so paranoid?

### DIFF
--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -102,7 +102,7 @@ module AmiSpec
     last_error = ''
     while retries > 0
       begin
-        Net::SSH.start(ip, user, keys: [key_file]) { |ssh| ssh.exec 'echo boo!'}
+        Net::SSH.start(ip, user, keys: [key_file], paranoid: false) { |ssh| ssh.exec 'echo boo!'}
       rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, Timeout::Error => error
         last_error = error
       else

--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -27,7 +27,7 @@ module AmiSpec
 
       set :backend, :ssh
       set :host, @ip
-      set :ssh_options, :user => @user, :keys => [@key_file]
+      set :ssh_options, :user => @user, :keys => [@key_file], :paranoid => false
 
       RSpec.configuration.fail_fast = true if @debug
 


### PR DESCRIPTION
Instances are launched inside a subnet with DHCP so will regularly clash
on IP and have different fingerprints.

This change ignores ssh fingerprints.
