### PR TITLE
Invalidate ssh connection

### DIFF
--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -3,7 +3,7 @@
 require 'rspec'
 require 'serverspec'
 
-# I hate Monkeys
+# The Monkey Patch can be removed once https://github.com/mizzy/specinfra/pull/504 is merged
 class Specinfra::Backend::Base
   def self.clear
     @instance = nil


### PR DESCRIPTION
To prevent ServerSpec from using the existing SSH connection for each
test run. The Monkey Patch can be removed once
mizzy/specinfra#504 is merged
