### PR TITLE
Allow us to wait for SystemV to start

### DIFF
--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -97,7 +97,7 @@ module AmiSpec
       opt :ssh_retries, "The number of times we should try sshing to the ec2 instance before giving up. Defaults to 30",
           type: :int, default: 30
       opt :debug, "Don't terminate instances on exit"
-      opt :wait_for_rc, "Wait for oldschool SystemV scripts to run before conducting tests."
+      opt :wait_for_rc, "Wait for oldschool SystemV scripts to run before conducting tests. Currently only supports Ubuntu with upstart"
     end
 
     if options[:role] && options[:ami]

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -3,6 +3,7 @@ require 'ami_spec/aws_instance_options'
 require 'ami_spec/server_spec'
 require 'ami_spec/server_spec_options'
 require 'ami_spec/wait_for_ssh'
+require 'ami_spec/wait_for_rc'
 require 'trollop'
 
 module AmiSpec

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -50,6 +50,7 @@ module AmiSpec
     instances.each do |instance|
       ip_address = options[:aws_public_ip] ? instance.public_ip_address : instance.private_ip_address
       WaitForSSH.wait(ip_address, options[:ssh_user], options[:key_file], options[:ssh_retries])
+      WaitForRC.wait(ip_address, options[:ssh_user], options[:key_file]) if options[:wait_for_rc]
 
       server_spec_options = ServerSpecOptions.new(options.merge(instance: instance))
       results << ServerSpec.new(server_spec_options).run
@@ -95,6 +96,7 @@ module AmiSpec
       opt :ssh_retries, "The number of times we should try sshing to the ec2 instance before giving up. Defaults to 30",
           type: :int, default: 30
       opt :debug, "Don't terminate instances on exit"
+      opt :wait_for_rc, "Wait for oldschool SystemV scripts to run before conducting tests."
     end
 
     if options[:role] && options[:ami]

--- a/lib/ami_spec/wait_for_rc.rb
+++ b/lib/ami_spec/wait_for_rc.rb
@@ -3,21 +3,12 @@ require 'net/ssh'
 module AmiSpec
   class WaitForRC
     def self.wait(ip_address, user, key)
-      loop do
-        begin
-          Net::SSH.start(ip_address, user, keys: [key], paranoid: false) do |ssh|
-            # Wait for SystemV to start
-            # This only works for Ubuntu with upstart.
-            # Detecting OS and Release will need something like this
-            # https://github.com/mizzy/specinfra/blob/master/lib/specinfra/helper/detect_os/debian.rb
-            ssh.exec 'while /usr/sbin/service rc status | grep -q "^rc start/running, process"; do sleep 1; done'
-          end
-          break
-        rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, Timeout::Error => error
-          sleep 1
-        else
-          break
-        end
+      Net::SSH.start(ip_address, user, keys: [key], paranoid: false) do |ssh|
+        # Wait for SystemV to start
+        # This only works for Ubuntu with upstart.
+        # Detecting OS and Release will need something like this
+        # https://github.com/mizzy/specinfra/blob/master/lib/specinfra/helper/detect_os/debian.rb
+        ssh.exec 'while /usr/sbin/service rc status | grep -q "^rc start/running, process"; do sleep 1; done'
       end
     end
   end

--- a/lib/ami_spec/wait_for_rc.rb
+++ b/lib/ami_spec/wait_for_rc.rb
@@ -1,0 +1,25 @@
+require 'net/ssh'
+
+module AmiSpec
+  class WaitForRC
+    def self.wait(ip_address, user, key)
+      loop do
+        begin
+          Net::SSH.start(ip_address, user, keys: [key], paranoid: false) do |ssh|
+            # Wait for SystemV to start
+            # This only works for Ubuntu with upstart.
+            # Detecting OS and Release will need something like this
+            # https://github.com/mizzy/specinfra/blob/master/lib/specinfra/helper/detect_os/debian.rb
+            ssh.exec 'while /usr/sbin/service rc status | grep -q "^rc start/running, process"; do sleep 1; done'
+          end
+          break
+        rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, Timeout::Error => error
+          sleep 1
+        else
+          break
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
When running tests that check certain daemons to start, if those daemons are using the old style SystemV this often results in flakey tests, because SSH will start before they do.

This feature introduces a flag (off by default) that waits for RC to start before starting tests.

Currently it only supports Ubuntu with upstart, checking for the actual OS release will require some trickery but we can run the same command and just check for different output (`Active: active (running) since`)