### PR TITLE
Add cli option to support custom tags

### DIFF
--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -98,7 +98,7 @@ module AmiSpec
       opt :aws_public_ip, "Launch instances with a public IP"
       opt :ssh_retries, "The number of times we should try sshing to the ec2 instance before giving up. Defaults to 30",
           type: :int, default: 30
-      opt :tags, "Additional tags to add to launched instances in the form of comma separated key=value pairs. i.e. Name=AmiSpec", type: string, default: ""
+      opt :tags, "Additional tags to add to launched instances in the form of comma separated key=value pairs. i.e. Name=AmiSpec", type: :string, default: ""
       opt :debug, "Don't terminate instances on exit"
       opt :wait_for_rc, "Wait for oldschool SystemV scripts to run before conducting tests. Currently only supports Ubuntu with upstart"
     end

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -36,6 +36,8 @@ module AmiSpec
   #   The username to SSH to the AMI with.
   # ssh_retries::
   #   Set the maximum number of ssh retries while waiting for the instance to boot.
+  # tags:::
+  #   Additional tags to add to launched instances in the form of comma separated key=value pairs
   # debug::
   #   Don't terminate the instances on exit
   # == Returns:
@@ -96,6 +98,7 @@ module AmiSpec
       opt :aws_public_ip, "Launch instances with a public IP"
       opt :ssh_retries, "The number of times we should try sshing to the ec2 instance before giving up. Defaults to 30",
           type: :int, default: 30
+      opt :tags, "Additional tags to add to launched instances in the form of comma separated key=value pairs. i.e. Name=AmiSpec", type: string, default: ""
       opt :debug, "Don't terminate instances on exit"
       opt :wait_for_rc, "Wait for oldschool SystemV scripts to run before conducting tests. Currently only supports Ubuntu with upstart"
     end
@@ -113,6 +116,14 @@ module AmiSpec
       fail "You must specify either role and ami or role_ami_file"
     end
 
+    options[:tags] = parse_tags(options[:tags])
+
     exit run(options)
+  end
+
+  def self.parse_tags(tags)
+    tag_pairs = tags.split(',')
+    tag_key_values = tag_pairs.collect{ |pair| pair.split('=')}.flatten
+    Hash[*tag_key_values]
   end
 end

--- a/lib/ami_spec/aws_instance.rb
+++ b/lib/ami_spec/aws_instance.rb
@@ -20,6 +20,7 @@ module AmiSpec
       @public_ip = options.fetch(:aws_public_ip)
       @region = options.fetch(:aws_region)
       @security_group_ids = options.fetch(:aws_security_groups)
+      @tags = ec2ify_tags(options.fetch(:tags, {}))
     end
 
     def_delegators :@instance, :instance_id, :tags, :terminate, :private_ip_address, :public_ip_address
@@ -37,6 +38,10 @@ module AmiSpec
 
     def client_options
       !@region.nil? ? {region: @region} : {}
+    end
+
+    def ec2ify_tags(tags)
+      tags.map { |k,v| {key: k, value: v} }
     end
 
     def instances_options
@@ -61,7 +66,7 @@ module AmiSpec
     end
 
     def tag_instance
-      @instance.create_tags(tags: [{ key: 'AmiSpec', value: @role }])
+      @instance.create_tags(tags: [{ key: 'AmiSpec', value: @role }] + @tags)
     end
   end
 end

--- a/lib/ami_spec/aws_instance.rb
+++ b/lib/ami_spec/aws_instance.rb
@@ -20,7 +20,7 @@ module AmiSpec
       @public_ip = options.fetch(:aws_public_ip)
       @region = options.fetch(:aws_region)
       @security_group_ids = options.fetch(:aws_security_groups)
-      @tags = ec2ify_tags(options.fetch(:tags, {}))
+      @tags = ec2ify_tags(options.fetch(:tags))
     end
 
     def_delegators :@instance, :instance_id, :tags, :terminate, :private_ip_address, :public_ip_address

--- a/lib/ami_spec/aws_instance_options.rb
+++ b/lib/ami_spec/aws_instance_options.rb
@@ -12,5 +12,6 @@ module AmiSpec
     property :aws_public_ip
     property :aws_region
     property :aws_security_groups
+    property :tags
   end
 end

--- a/spec/ami_spec_spec.rb
+++ b/spec/ami_spec_spec.rb
@@ -66,5 +66,9 @@ describe AmiSpec do
     it 'parses multiple key/value pairs' do
       expect(described_class.parse_tags("Name=AmiSpec,Owner=Me")).to eq( { "Name"=>"AmiSpec", "Owner"=>"Me" } )
     end
+
+    it 'parses an empty string' do
+      expect(described_class.parse_tags("")).to eq({})
+    end
   end
 end

--- a/spec/ami_spec_spec.rb
+++ b/spec/ami_spec_spec.rb
@@ -51,4 +51,14 @@ describe AmiSpec do
       end
     end
   end
+
+  describe '#parse_tags' do
+    it 'parses a single key/value pair' do
+      expect(described_class.parse_tags("Name=AmiSpec")).to eq( { "Name"=>"AmiSpec" } )
+    end
+
+    it 'parses multiple key/value pairs' do
+      expect(described_class.parse_tags("Name=AmiSpec,Owner=Me")).to eq( { "Name"=>"AmiSpec", "Owner"=>"Me" } )
+    end
+  end
 end

--- a/spec/ami_spec_spec.rb
+++ b/spec/ami_spec_spec.rb
@@ -21,6 +21,12 @@ describe AmiSpec do
     )
   end
 
+  describe '#invoke' do
+    it 'raises a system exit with no arguments' do
+      expect{ described_class.invoke }.to raise_error(SystemExit)
+    end
+  end
+
   describe '#run' do
     before do
       allow(AmiSpec::WaitForSSH).to receive(:wait).and_return(true)

--- a/spec/aws_instance_spec.rb
+++ b/spec/aws_instance_spec.rb
@@ -7,6 +7,7 @@ describe AmiSpec::AwsInstance do
   let(:client_double) { instance_double(Aws::EC2::Client) }
   let(:new_ec2_double) { instance_double(Aws::EC2::Types::Instance) }
   let(:ec2_double) { instance_double(Aws::EC2::Instance) }
+  let(:tags) { {} }
   subject(:aws_instance) do
     described_class.new(
       role: role,
@@ -16,7 +17,8 @@ describe AmiSpec::AwsInstance do
       aws_instance_type: 't2.micro',
       aws_public_ip: false,
       aws_security_groups: sec_group_id,
-      aws_region: region
+      aws_region: region,
+      tags: tags
     )
   end
 
@@ -74,6 +76,17 @@ describe AmiSpec::AwsInstance do
                                         anything,
                                         hash_including(:region => region)
                                       )
+        start
+      end
+    end
+
+    context 'with tags' do
+      let(:tags) { {"Name" => "AmiSpec"} }
+
+      it 'tags the instance' do
+        expect(ec2_double).to receive(:create_tags).with(
+                                 {tags: [{ key: 'AmiSpec', value: role}, { key: "Name", value: "AmiSpec"}]}
+                               )
         start
       end
     end


### PR DESCRIPTION
Sometimes we need to tag our instances as we create them, to allow us to lock down permissions of certain IAM roles and increase accountability around billing.

This change creates a command line option to allow users to add custom tags to instances launched by AmiSpec.