### PR TITLE
Add a buildkite output option

### DIFF
--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -40,6 +40,8 @@ module AmiSpec
   #   Additional tags to add to launched instances in the form of comma separated key=value pairs
   # debug::
   #   Don't terminate the instances on exit
+  # buildkite::
+  #   Output section separators for buildkite
   # == Returns:
   # Boolean - The result of all the server specs.
   def self.run(options)
@@ -100,6 +102,7 @@ module AmiSpec
           type: :int, default: 30
       opt :tags, "Additional tags to add to launched instances in the form of comma separated key=value pairs. i.e. Name=AmiSpec", type: :string, default: ""
       opt :debug, "Don't terminate instances on exit"
+      opt :buildkite, "Output section separators for buildkite"
       opt :wait_for_rc, "Wait for oldschool SystemV scripts to run before conducting tests. Currently only supports Ubuntu with upstart"
     end
 

--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -15,10 +15,15 @@ module AmiSpec
       @spec = options.fetch(:specs)
       @user = options.fetch(:ssh_user)
       @key_file = options.fetch(:key_file)
+      @buildkite = options.fetch(:buildkite)
     end
 
     def run
-      puts "Running tests for #{@role}"
+      if @buildkite
+        puts "--- Running tests for #{@role}"
+      else
+        puts "Running tests for #{@role}"
+      end
 
       $LOAD_PATH.unshift(@spec) unless $LOAD_PATH.include?(@spec)
       require File.join(@spec, 'spec_helper')
@@ -38,6 +43,7 @@ module AmiSpec
 
       Specinfra::Backend::Ssh.clear
 
+      puts "^^^ +++" if @buildkite && !result.zero?
       result.zero?
     end
   end

--- a/lib/ami_spec/server_spec_options.rb
+++ b/lib/ami_spec/server_spec_options.rb
@@ -10,5 +10,6 @@ module AmiSpec
     property :key_file
     property :specs
     property :ssh_user
+    property :buildkite
   end
 end


### PR DESCRIPTION
Testing multiple instance types is annoying because all the output is merged into one section in buildkite. Add an option for buildkite-compatible output (see [docs](https://buildkite.com/docs/builds/managing-log-output#collapsing-output)), so that each instance has its own section and errors open only the relevant sections by default.