### PR TITLE
User data and iam instance profile arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,32 +29,34 @@ Run `bundle install`
 ```cli
 $ bundle exec ami_spec --help
 Options:
-  -r, --role=<s>                    The role to test, this should map to a directory in the spec folder
-  -a, --ami=<s>                     The ami ID to run tests against
-  -o, --role-ami-file=<s>           A file containing comma separated roles and amis. i.e.
-                                    web_server,ami-id.
-  -s, --specs=<s>                   The directory to find ServerSpecs
-  -u, --subnet-id=<s>               The subnet to start the instance in
-  -k, --key-name=<s>                The SSH key name to assign to instances
-  -e, --key-file=<s>                The SSH private key file associated to the key_name
-  -h, --ssh-user=<s>                The user to ssh to the instance as
-  -w, --aws-region=<s>              The AWS region, defaults to AWS_DEFAULT_REGION environment variable
-  -i, --aws-instance-type=<s>       The ec2 instance type, defaults to t2.micro (default: t2.micro)
-  -c, --aws-security-groups=<s+>    Security groups to associate to the launched instances. May be specified
-                                    multiple times
-  -p, --aws-public-ip               Launch instances with a public IP
-  -t, --ssh-retries=<i>             The number of times we should try sshing to the ec2 instance before
-                                    giving up. Defaults to 30 (default: 30)
-  -d, --debug                       Don't terminate instances on exit
-  -l, --help                        Show this message
-$  bundle exec ami_spec \
---role web_server \
---ami ami-12345678 \
---subnet-id subnet-abcdefgh \
---key-name ec2-key-pair \
---key-file ~/.ssh/ec2-key-pair.pem \
---ssh-user ubuntu \
---specs ./my_project/spec
+  -r, --role=<s>                        The role to test, this should map to a directory in the spec
+                                        folder
+  -a, --ami=<s>                         The ami ID to run tests against
+  -o, --role-ami-file=<s>               A file containing comma separated roles and amis. i.e.
+                                        web_server,ami-id.
+  -s, --specs=<s>                       The directory to find ServerSpecs
+  -u, --subnet-id=<s>                   The subnet to start the instance in
+  -k, --key-name=<s>                    The SSH key name to assign to instances
+  -e, --key-file=<s>                    The SSH private key file associated to the key_name
+  -h, --ssh-user=<s>                    The user to ssh to the instance as
+  -w, --aws-region=<s>                  The AWS region, defaults to AWS_DEFAULT_REGION environment
+                                        variable
+  -i, --aws-instance-type=<s>           The ec2 instance type, defaults to t2.micro (default:
+                                        t2.micro)
+  -c, --aws-security-groups=<s+>        Security groups to associate to the launched instances. May be
+                                        specified multiple times
+  -p, --aws-public-ip                   Launch instances with a public IP
+  -t, --ssh-retries=<i>                 The number of times we should try sshing to the ec2 instance
+                                        before giving up. Defaults to 30 (default: 30)
+  -g, --tags=<s>                        Additional tags to add to launched instances in the form of
+                                        comma separated key=value pairs. i.e. Name=AmiSpec (default: )
+  -d, --debug                           Don't terminate instances on exit
+  -f, --wait-for-rc                     Wait for oldschool SystemV scripts to run before conducting
+                                        tests. Currently only supports Ubuntu with upstart
+  -l, --user-data-file=<s>              File path for aws ec2 user data
+  -m, --iam-instance-profile-arn=<s>    IAM instance profile to use
+  --help                                Show this message
+
 ```
 
 AmiSpec will launch an EC2 instance from the given AMI (`--ami`), in a subnet (`--subnet-id`) with a key-pair (`--key-name`)

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -101,6 +101,7 @@ module AmiSpec
       opt :tags, "Additional tags to add to launched instances in the form of comma separated key=value pairs. i.e. Name=AmiSpec", type: :string, default: ""
       opt :debug, "Don't terminate instances on exit"
       opt :wait_for_rc, "Wait for oldschool SystemV scripts to run before conducting tests. Currently only supports Ubuntu with upstart"
+      opt :user_data_file, "File path for aws ec2 user data", type: :string
     end
 
     if options[:role] && options[:ami]
@@ -118,6 +119,10 @@ module AmiSpec
 
     unless File.exist? options[:key_file]
       fail "Key file #{options[:key_file]} not found"
+    end
+
+    unless options[:user_data_file] and File.exist? options[:user_data_file]
+      fail "User Data file #{options[:user_data_file]} not found"
     end
 
     options[:tags] = parse_tags(options[:tags])

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -102,6 +102,7 @@ module AmiSpec
       opt :debug, "Don't terminate instances on exit"
       opt :wait_for_rc, "Wait for oldschool SystemV scripts to run before conducting tests. Currently only supports Ubuntu with upstart"
       opt :user_data_file, "File path for aws ec2 user data", type: :string
+      opt :iam_instance_profile_arn, "IAM instance profile to use", type: :string
     end
 
     if options[:role] && options[:ami]

--- a/lib/ami_spec/aws_instance.rb
+++ b/lib/ami_spec/aws_instance.rb
@@ -61,10 +61,9 @@ module AmiSpec
         }]
       }
 
-      puts @user_data_file
-      params[:user_data] = Base64.encode64(File.read(@user_data_file)) unless @user_data_file == nil
+      params[:user_data] = Base64.encode64(File.read(@user_data_file)) unless @user_data_file.nil?
 
-      unless @iam_instance_profile_arn == nil
+      unless @iam_instance_profile_arn.nil?
         params[:iam_instance_profile] = {
             arn: @iam_instance_profile_arn
         }

--- a/lib/ami_spec/aws_instance.rb
+++ b/lib/ami_spec/aws_instance.rb
@@ -1,5 +1,6 @@
 require 'aws-sdk'
 require 'forwardable'
+require 'base64'
 
 module AmiSpec
   class AwsInstance
@@ -21,6 +22,7 @@ module AmiSpec
       @region = options.fetch(:aws_region)
       @security_group_ids = options.fetch(:aws_security_groups)
       @tags = ec2ify_tags(options.fetch(:tags))
+      @user_data_file = options.key?(:user_data_file) ? options.fetch(:user_data_file) : nil
     end
 
     def_delegators :@instance, :instance_id, :tags, :terminate, :private_ip_address, :public_ip_address
@@ -57,6 +59,8 @@ module AmiSpec
           subnet_id: @subnet_id,
         }]
       }
+
+      params[:user_data] = Base64.encode64(File.read(@user_data_file)) unless @user_data_file == nil
 
       unless @security_group_ids.nil?
         params[:network_interfaces][0][:groups] = @security_group_ids

--- a/lib/ami_spec/aws_instance.rb
+++ b/lib/ami_spec/aws_instance.rb
@@ -23,6 +23,7 @@ module AmiSpec
       @security_group_ids = options.fetch(:aws_security_groups)
       @tags = ec2ify_tags(options.fetch(:tags))
       @user_data_file = options.key?(:user_data_file) ? options.fetch(:user_data_file) : nil
+      @iam_instance_profile_arn = options.key?(:iam_instance_profile_arn) ? options.fetch(:iam_instance_profile_arn) : nil
     end
 
     def_delegators :@instance, :instance_id, :tags, :terminate, :private_ip_address, :public_ip_address
@@ -60,7 +61,14 @@ module AmiSpec
         }]
       }
 
+      puts @user_data_file
       params[:user_data] = Base64.encode64(File.read(@user_data_file)) unless @user_data_file == nil
+
+      unless @iam_instance_profile_arn == nil
+        params[:iam_instance_profile] = {
+            arn: @iam_instance_profile_arn
+        }
+      end
 
       unless @security_group_ids.nil?
         params[:network_interfaces][0][:groups] = @security_group_ids

--- a/lib/ami_spec/aws_instance.rb
+++ b/lib/ami_spec/aws_instance.rb
@@ -22,8 +22,8 @@ module AmiSpec
       @region = options.fetch(:aws_region)
       @security_group_ids = options.fetch(:aws_security_groups)
       @tags = ec2ify_tags(options.fetch(:tags))
-      @user_data_file = options.key?(:user_data_file) ? options.fetch(:user_data_file) : nil
-      @iam_instance_profile_arn = options.key?(:iam_instance_profile_arn) ? options.fetch(:iam_instance_profile_arn) : nil
+      @user_data_file = options.fetch(:user_data_file, nil)
+      @iam_instance_profile_arn = options.fetch(:iam_instance_profile_arn, nil)
     end
 
     def_delegators :@instance, :instance_id, :tags, :terminate, :private_ip_address, :public_ip_address

--- a/lib/ami_spec/aws_instance_options.rb
+++ b/lib/ami_spec/aws_instance_options.rb
@@ -13,5 +13,6 @@ module AmiSpec
     property :aws_region
     property :aws_security_groups
     property :tags
+    property :user_data_file
   end
 end

--- a/lib/ami_spec/aws_instance_options.rb
+++ b/lib/ami_spec/aws_instance_options.rb
@@ -14,5 +14,6 @@ module AmiSpec
     property :aws_security_groups
     property :tags
     property :user_data_file
+    property :iam_instance_profile_arn
   end
 end

--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -15,8 +15,8 @@ module AmiSpec
       @spec = options.fetch(:specs)
       @user = options.fetch(:ssh_user)
       @key_file = options.fetch(:key_file)
-      @user_data_file= options.fetch(:user_data_file)
-      @iam_instance_profile_arn= options.fetch(:user_data_file)
+      @user_data_file = options.fetch(:user_data_file)
+      @iam_instance_profile_arn = options.fetch(:user_data_file)
     end
 
     def run

--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -16,6 +16,7 @@ module AmiSpec
       @user = options.fetch(:ssh_user)
       @key_file = options.fetch(:key_file)
       @user_data_file= options.fetch(:user_data_file)
+      @iam_instance_profile_arn= options.fetch(:user_data_file)
     end
 
     def run

--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -15,6 +15,7 @@ module AmiSpec
       @spec = options.fetch(:specs)
       @user = options.fetch(:ssh_user)
       @key_file = options.fetch(:key_file)
+      @user_data_file= options.fetch(:user_data_file)
     end
 
     def run

--- a/lib/ami_spec/server_spec_options.rb
+++ b/lib/ami_spec/server_spec_options.rb
@@ -11,5 +11,6 @@ module AmiSpec
     property :specs
     property :ssh_user
     property :user_data_file
+    property :iam_instance_profile_arn
   end
 end

--- a/lib/ami_spec/server_spec_options.rb
+++ b/lib/ami_spec/server_spec_options.rb
@@ -10,5 +10,6 @@ module AmiSpec
     property :key_file
     property :specs
     property :ssh_user
+    property :user_data_file
   end
 end

--- a/lib/ami_spec/version.rb
+++ b/lib/ami_spec/version.rb
@@ -1,3 +1,3 @@
 module AmiSpec
-  VERSION = '0.4.1'
+  VERSION = '0.3.0'
 end

--- a/lib/ami_spec/version.rb
+++ b/lib/ami_spec/version.rb
@@ -1,3 +1,3 @@
 module AmiSpec
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/lib/ami_spec/version.rb
+++ b/lib/ami_spec/version.rb
@@ -1,3 +1,3 @@
 module AmiSpec
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
This change is helpful for testing boot time events such as cloud-init scripts and/or talking to aws services at boot time.