### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
- - 2.1.8
- - 2.2.4
+ - 2.2.6
  - 2.4.4
  - 2.5.1
 script: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ rvm:
  - 2.2.6
  - 2.4.4
  - 2.5.1
+ - 2.6.1
 script: bundle exec rake spec

--- a/ami_spec.gemspec
+++ b/ami_spec.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'specinfra', '>= 2.45'
   gem.add_dependency 'optimist'
   gem.add_dependency 'hashie'
-  gem.add_dependency 'net-ssh', '< 3.0'
+  gem.add_dependency 'net-ssh', '~> 5'
 end

--- a/ami_spec.gemspec
+++ b/ami_spec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rake'
   gem.add_dependency 'serverspec'
   gem.add_dependency 'specinfra', '>= 2.45'
-  gem.add_dependency 'trollop'
+  gem.add_dependency 'optimist'
   gem.add_dependency 'hashie'
   gem.add_dependency 'net-ssh', '< 3.0'
 end

--- a/ami_spec.gemspec
+++ b/ami_spec.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'aws-sdk-ec2'
+  gem.add_dependency 'aws-sdk-ec2', '~> 1'
   gem.add_dependency 'rake'
-  gem.add_dependency 'serverspec'
+  gem.add_dependency 'serverspec', '~> 2'
   gem.add_dependency 'specinfra', '>= 2.45'
-  gem.add_dependency 'optimist'
+  gem.add_dependency 'optimist', '~> 3'
   gem.add_dependency 'hashie'
   gem.add_dependency 'net-ssh', '~> 5'
 end

--- a/ami_spec.gemspec
+++ b/ami_spec.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'aws-sdk-ec2', '~> 1'
-  gem.add_dependency 'rake'
+  gem.add_development_dependency 'rake'
   gem.add_dependency 'serverspec', '~> 2'
   gem.add_dependency 'specinfra', '>= 2.45'
   gem.add_dependency 'optimist', '~> 3'

--- a/bin/ami_spec
+++ b/bin/ami_spec
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'trollop'
 require 'ami_spec'
 
 AmiSpec.invoke

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -4,7 +4,7 @@ require 'ami_spec/server_spec'
 require 'ami_spec/server_spec_options'
 require 'ami_spec/wait_for_ssh'
 require 'ami_spec/wait_for_rc'
-require 'trollop'
+require 'optimist'
 
 module AmiSpec
   class InstanceConnectionTimeout < StandardError; end
@@ -83,7 +83,7 @@ module AmiSpec
   private_class_method :stop_instances
 
   def self.invoke
-    options = Trollop::options do
+    options = Optimist::options do
       opt :role, "The role to test, this should map to a directory in the spec folder", type: :string
       opt :ami, "The ami ID to run tests against", type: :string
       opt :role_ami_file, "A file containing comma separated roles and amis. i.e.\nweb_server,ami-id.",


### PR DESCRIPTION
Currently AMISpec prints a lot of deprecation warnings:

```
[DEPRECATION] This gem has been renamed to optimist and will no longer be supported. Please switch to optimist as soon as possible.
...
/Users/patrickrobinson/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-ssh-2.9.4/lib/net/ssh/transport/session.rb:67:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/patrickrobinson/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-ssh-2.9.4/lib/net/ssh/transport/session.rb:84:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/patrickrobinson/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-ssh-2.9.4/lib/net/ssh/transport/cipher_factory.rb:98: warning: constant OpenSSL::Cipher::Cipher is deprecated
/Users/patrickrobinson/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-ssh-2.9.4/lib/net/ssh/transport/cipher_factory.rb:72: warning: constant OpenSSL::Cipher::Cipher is deprecated
```

This PR removes those warning by upgrading net-ssh and updating to use the Optimist Gem.

We also pin some important gems to a specific major version

Finally we drop support for Ruby < 2.2.6, as net-ssh 5.x does not support it.