### PR TITLE
Fail the build if a specified role is missing specs

### DIFF
--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -131,6 +131,12 @@ module AmiSpec
 
     options[:tags] = parse_tags(options[:tags])
 
+    options[:amis].each_pair do |role, _|
+      unless Dir.exist?("#{options[:specs]}/#{role}")
+        fail "Role directory #{options[:specs]}/#{role} does not exist. If you'd like to skip the role '#{role}', create the directory but leave it empty (except for a .gitignore file)."
+      end
+    end
+
     exit run(options)
   end
 

--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -29,7 +29,7 @@ module AmiSpec
 
       unless Dir.exist?("#{@spec}/#{@role}")
         puts "WARNING: Role directory #{@spec}/#{@role} does not exist. If you'd like to"
-        puts "skip the role '#{role}', create the directory but leave it empty"
+        puts "skip the role '#{@role}', create the directory but leave it empty"
         puts "(except for a .gitkeep file)."
         return false
       end

--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -27,13 +27,6 @@ module AmiSpec
         puts "Running tests for #{@role}"
       end
 
-      unless Dir.exist?("#{@spec}/#{@role}")
-        puts "WARNING: Role directory #{@spec}/#{@role} does not exist. If you'd like to"
-        puts "skip the role '#{@role}', create the directory but leave it empty"
-        puts "(except for a .gitkeep file)."
-        return false
-      end
-
       $LOAD_PATH.unshift(@spec) unless $LOAD_PATH.include?(@spec)
       begin
         require File.join(@spec, 'spec_helper')
@@ -46,7 +39,6 @@ module AmiSpec
       set :ssh_options, :user => @user, :keys => [@key_file], :paranoid => false
 
       RSpec.configuration.fail_fast = true if @debug
-
 
       RSpec::Core::Runner.disable_autorun!
       result = RSpec::Core::Runner.run(Dir.glob("#{@spec}/#{@role}/*_spec.rb"))

--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -27,6 +27,13 @@ module AmiSpec
         puts "Running tests for #{@role}"
       end
 
+      unless Dir.exist?("#{@spec}/#{@role}")
+        puts "WARNING: Role directory #{@spec}/#{@role} does not exist. If you'd like to"
+        puts "skip the role '#{role}', create the directory but leave it empty"
+        puts "(except for a .gitkeep file)."
+        return false
+      end
+
       $LOAD_PATH.unshift(@spec) unless $LOAD_PATH.include?(@spec)
       begin
         require File.join(@spec, 'spec_helper')
@@ -39,6 +46,7 @@ module AmiSpec
       set :ssh_options, :user => @user, :keys => [@key_file], :paranoid => false
 
       RSpec.configuration.fail_fast = true if @debug
+
 
       RSpec::Core::Runner.disable_autorun!
       result = RSpec::Core::Runner.run(Dir.glob("#{@spec}/#{@role}/*_spec.rb"))


### PR DESCRIPTION
Not sure on implementation here - I feel like there should be a more rspeccy way of doing this, preferably with a nice red rspec failure.

Anyway, this not failing fast caused lots of confusion as our passing build was not actually running tests against some of the roles it had been told to.