### PR TITLE
Generate temporary key pairs in AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ Options:
   -s, --specs=<s>                       The directory to find ServerSpecs
   -u, --subnet-id=<s>                   The subnet to start the instance in
   -k, --key-name=<s>                    The SSH key name to assign to instances
+  -k, --key-name=<s>                    The SSH key name to assign to instances. If not provided a
+                                        temporary key pair will be generated in AWS
   -e, --key-file=<s>                    The SSH private key file associated to the key_name
   -h, --ssh-user=<s>                    The user to ssh to the instance as
   -w, --aws-region=<s>                  The AWS region, defaults to AWS_DEFAULT_REGION environment
                                         variable
   -i, --aws-instance-type=<s>           The ec2 instance type, defaults to t2.micro (default:
                                         t2.micro)
-  -c, --aws-security-groups=<s+>        Security groups to associate to the launched instances. May be
+  -c, --aws-security-groups=<s>         Security groups to associate to the launched instances. May be
                                         specified multiple times
   -p, --aws-public-ip                   Launch instances with a public IP
   -t, --ssh-retries=<i>                 The number of times we should try sshing to the ec2 instance
@@ -51,6 +53,7 @@ Options:
   -g, --tags=<s>                        Additional tags to add to launched instances in the form of
                                         comma separated key=value pairs. i.e. Name=AmiSpec (default: )
   -d, --debug                           Don't terminate instances on exit
+  -b, --buildkite                       Output section separators for buildkite
   -f, --wait-for-rc                     Wait for oldschool SystemV scripts to run before conducting
                                         tests. Currently only supports Ubuntu with upstart
   -l, --user-data-file=<s>              File path for aws ec2 user data

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Options:
                                         web_server,ami-id.
   -s, --specs=<s>                       The directory to find ServerSpecs
   -u, --subnet-id=<s>                   The subnet to start the instance in
-  -k, --key-name=<s>                    The SSH key name to assign to instances
   -k, --key-name=<s>                    The SSH key name to assign to instances. If not provided a
                                         temporary key pair will be generated in AWS
   -e, --key-file=<s>                    The SSH private key file associated to the key_name

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -6,6 +6,7 @@ require 'ami_spec/server_spec_options'
 require 'ami_spec/wait_for_ssh'
 require 'ami_spec/wait_for_rc'
 require 'optimist'
+require 'logger'
 
 module AmiSpec
   class InstanceConnectionTimeout < StandardError; end
@@ -46,10 +47,12 @@ module AmiSpec
   # == Returns:
   # Boolean - The result of all the server specs.
   def self.run(options)
+    logger = Logger.new(STDOUT, formatter: proc { |_sev, _time, _name, message| "#{message}\n" })
+
     ec2 = Aws::EC2::Resource.new(options[:aws_region] ? {region: options[:aws_region]} : {})
 
     unless options[:key_name]
-      key_pair = AwsKeyPair.create(ec2: ec2)
+      key_pair = AwsKeyPair.create(ec2: ec2, logger: logger)
       options[:key_name] = key_pair.key_name
       options[:key_file] = key_pair.key_file
     end

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -1,5 +1,6 @@
 require 'ami_spec/aws_instance'
 require 'ami_spec/aws_instance_options'
+require 'ami_spec/aws_key_pair'
 require 'ami_spec/server_spec'
 require 'ami_spec/server_spec_options'
 require 'ami_spec/wait_for_ssh'
@@ -19,7 +20,7 @@ module AmiSpec
   # subnet_id::
   #   The subnet_id to start instances in.
   # key_name::
-  #   The SSH key name to assign to instances. This key name must exist on the executing host for passwordless login.
+  #   The SSH key name to assign to instances. If not provided a temporary key pair will be generated in AWS
   # key_file::
   #   The SSH key file to use to connect to the host.
   # aws_region::
@@ -45,6 +46,14 @@ module AmiSpec
   # == Returns:
   # Boolean - The result of all the server specs.
   def self.run(options)
+    ec2 = Aws::EC2::Resource.new(options[:aws_region] ? {region: options[:aws_region]} : {})
+
+    unless options[:key_name]
+      key_pair = AwsKeyPair.create(ec2: ec2)
+      options[:key_name] = key_pair.key_name
+      options[:key_file] = key_pair.key_file
+    end
+
     instances = []
     options[:amis].each_pair do |role, ami|
       aws_instance_options = AwsInstanceOptions.new(options.merge(role: role, ami: ami))
@@ -64,6 +73,7 @@ module AmiSpec
     results.all?
   ensure
     stop_instances(instances, options[:debug])
+    key_pair.delete if key_pair
   end
 
   def self.stop_instances(instances, debug)
@@ -90,8 +100,9 @@ module AmiSpec
           type: :string
       opt :specs, "The directory to find ServerSpecs", type: :string, required: true
       opt :subnet_id, "The subnet to start the instance in", type: :string, required: true
-      opt :key_name, "The SSH key name to assign to instances", type: :string, required: true
-      opt :key_file, "The SSH private key file associated to the key_name", type: :string, required: true
+      opt :key_name, "The SSH key name to assign to instances. If not provided a temporary key pair will be generated in AWS",
+          type: :string
+      opt :key_file, "The SSH private key file associated to the key_name", type: :string
       opt :ssh_user, "The user to ssh to the instance as", type: :string, required: true
       opt :aws_region, "The AWS region, defaults to AWS_DEFAULT_REGION environment variable", type: :string
       opt :aws_instance_type, "The ec2 instance type, defaults to t2.micro", type: :string, default: 't2.micro'

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -135,9 +135,7 @@ module AmiSpec
       fail "You must specify either role and ami or role_ami_file"
     end
 
-    unless File.exist? options[:key_file]
-      fail "Key file #{options[:key_file]} not found"
-    end
+    fail "Key file #{options[:key_file]} not found" if options[:key_name] && !File.exist?(options.fetch(:key_file))
 
     if options[:user_data_file] and !File.exist? options[:user_data_file]
       fail "User Data file #{options[:user_data_file]} not found"

--- a/lib/ami_spec/aws_key_pair.rb
+++ b/lib/ami_spec/aws_key_pair.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-ec2'
+require 'logger'
 require 'securerandom'
 require 'tempfile'
 require 'pathname'
@@ -10,14 +11,16 @@ module AmiSpec
       new(**args).tap(&:create)
     end
 
-    def initialize(ec2: Aws::EC2::Resource.new, key_name_prefix: 'ami-spec-')
+    def initialize(ec2: Aws::EC2::Resource.new, key_name_prefix: 'ami-spec-', logger: Logger.new(STDOUT))
       @ec2 = ec2
       @key_name = "#{key_name_prefix}#{SecureRandom.uuid}"
+      @logger = logger
     end
 
     attr_reader :key_name, :key_file
 
     def create
+      @logger.info "Creating temporary AWS key pair: #{@key_name}"
       @key_pair = @ec2.create_key_pair(key_name: @key_name)
       @temp_file = Tempfile.new
       @temp_file.write(@key_pair.key_material)
@@ -26,6 +29,7 @@ module AmiSpec
     end
 
     def delete
+      @logger.info "Deleting temporary AWS key pair: #{@key_name}"
       @key_pair.delete
     end
   end

--- a/lib/ami_spec/aws_key_pair.rb
+++ b/lib/ami_spec/aws_key_pair.rb
@@ -1,0 +1,32 @@
+require 'aws-sdk-ec2'
+require 'securerandom'
+require 'tempfile'
+require 'pathname'
+
+module AmiSpec
+  class AwsKeyPair
+
+    def self.create(**args)
+      new(**args).tap(&:create)
+    end
+
+    def initialize(ec2: Aws::EC2::Resource.new, key_name_prefix: 'ami-spec-')
+      @ec2 = ec2
+      @key_name = "#{key_name_prefix}#{SecureRandom.uuid}"
+    end
+
+    attr_reader :key_name, :key_file
+
+    def create
+      @key_pair = @ec2.create_key_pair(key_name: @key_name)
+      @temp_file = Tempfile.new
+      @temp_file.write(@key_pair.key_material)
+      @temp_file.close
+      @key_file = Pathname.new(@temp_file.path)
+    end
+
+    def delete
+      @key_pair.delete
+    end
+  end
+end

--- a/lib/ami_spec/aws_key_pair.rb
+++ b/lib/ami_spec/aws_key_pair.rb
@@ -22,7 +22,7 @@ module AmiSpec
     def create
       @logger.info "Creating temporary AWS key pair: #{@key_name}"
       @key_pair = @ec2.create_key_pair(key_name: @key_name)
-      @temp_file = Tempfile.new
+      @temp_file = Tempfile.new('key')
       @temp_file.write(@key_pair.key_material)
       @temp_file.close
       @key_file = Pathname.new(@temp_file.path)

--- a/spec/ami_spec/aws_key_pair_spec.rb
+++ b/spec/ami_spec/aws_key_pair_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 describe AmiSpec::AwsKeyPair do
-  subject(:aws_key_pair) { described_class.create(ec2: ec2) }
+  subject(:aws_key_pair) { described_class.create(ec2: ec2, logger: logger) }
 
   let(:ec2) { instance_spy(Aws::EC2::Resource, create_key_pair: key_pair) }
   let(:key_pair) { instance_spy(Aws::EC2::KeyPair, key_material: key_material) }
   let(:key_material) { 'test-key-material' }
+  let(:logger) { instance_spy(Logger) }
 
   describe '#create' do
     subject(:create) { aws_key_pair }
@@ -13,6 +14,11 @@ describe AmiSpec::AwsKeyPair do
     it 'creates the key pair in AWS' do
       create
       expect(ec2).to have_received(:create_key_pair).with(key_name: aws_key_pair.key_name)
+    end
+
+    it 'logs the creation of the key pair in AWS' do
+      create
+      expect(logger).to have_received(:info).with "Creating temporary AWS key pair: #{aws_key_pair.key_name}"
     end
   end
 
@@ -40,6 +46,11 @@ describe AmiSpec::AwsKeyPair do
     it 'deletes the key pair in AWS' do
       delete
       expect(key_pair).to have_received(:delete)
+    end
+
+    it 'logs the deletion of the key pair in AWS' do
+      delete
+      expect(logger).to have_received(:info).with "Deleting temporary AWS key pair: #{aws_key_pair.key_name}"
     end
   end
 end

--- a/spec/ami_spec/aws_key_pair_spec.rb
+++ b/spec/ami_spec/aws_key_pair_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe AmiSpec::AwsKeyPair do
+  subject(:aws_key_pair) { described_class.create(ec2: ec2) }
+
+  let(:ec2) { instance_spy(Aws::EC2::Resource, create_key_pair: key_pair) }
+  let(:key_pair) { instance_spy(Aws::EC2::KeyPair, key_material: key_material) }
+  let(:key_material) { 'test-key-material' }
+
+  describe '#create' do
+    subject(:create) { aws_key_pair }
+
+    it 'creates the key pair in AWS' do
+      create
+      expect(ec2).to have_received(:create_key_pair).with(key_name: aws_key_pair.key_name)
+    end
+  end
+
+  describe '#key_name' do
+    subject(:key_name) { aws_key_pair.key_name }
+
+    it { should start_with('ami-spec-') }
+  end
+
+  describe '#key_file' do
+    subject(:key_file) { aws_key_pair.key_file }
+
+    it { should exist }
+
+    it 'should contain key material' do
+      expect(key_file.read).to eq(key_material)
+    end
+
+    it { should be_a Pathname }
+  end
+
+  describe '#delete' do
+    subject(:delete) { aws_key_pair.delete }
+
+    it 'deletes the key pair in AWS' do
+      delete
+      expect(key_pair).to have_received(:delete)
+    end
+  end
+end
+


### PR DESCRIPTION
It can be rather cumbersome to configure AWS key pairs. You have to add them in AWS and then ensure they're installed on CI servers and/or available to developers.

Instead of all that manual work, let's get AMI Spec to do it for us!

I propose that if a key name isn't provided via the command line, then a temporary key pair is generated in AWS and used for the duration of the testing. Afterward a best effort is given to delete the key pair.