### PR TITLE
Resolve Net SSH deprecations

### DIFF
--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -36,7 +36,7 @@ module AmiSpec
 
       set :backend, :ssh
       set :host, @ip
-      set :ssh_options, :user => @user, :keys => [@key_file], :paranoid => false
+      set :ssh_options, :user => @user, :keys => [@key_file], :verify_host_key => :never
 
       RSpec.configuration.fail_fast = true if @debug
 

--- a/lib/ami_spec/wait_for_rc.rb
+++ b/lib/ami_spec/wait_for_rc.rb
@@ -3,7 +3,7 @@ require 'net/ssh'
 module AmiSpec
   class WaitForRC
     def self.wait(ip_address, user, key, port=22)
-      Net::SSH.start(ip_address, user, keys: [key], paranoid: false, port: port) do |ssh|
+      Net::SSH.start(ip_address, user, keys: [key], :verify_host_key => :never, port: port) do |ssh|
         distrib_stdout = ""
         # Determine the OS family
         ssh.exec!("source /etc/*release && echo -n $DISTRIB_ID && echo -n $ID") do |channel, stream, data|

--- a/lib/ami_spec/wait_for_ssh.rb
+++ b/lib/ami_spec/wait_for_ssh.rb
@@ -8,7 +8,7 @@ module AmiSpec
 
       while retries < max_retries
         begin
-          Net::SSH.start(ip_address, user, keys: [key], paranoid: false) { |ssh| ssh.exec 'echo boo!' }
+          Net::SSH.start(ip_address, user, keys: [key], :verify_host_key => :never) { |ssh| ssh.exec 'echo boo!' }
         rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, Timeout::Error => error
           last_error = error
           sleep 1


### PR DESCRIPTION
### Context

When executing ami_spec I'm seeing a bunch of deprecation warnings:

```
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
verify_host_key: false is deprecated, use :never
```

These are being emitted by the [net-ssh] gem.

### Change
Migrate from `paranoid` Net SSH option to `verify_host_key`. And change its value from `false` to `:never`. This maintains the current behaviour.

### Considerations

From the [changelog], the `verify_host_key` was introduced in version 4.2.0.rc1, and the `:never` value in version 5.0.0. This is safe because ami_spec requires [net-ssh ~> 5](https://github.com/envato/ami-spec/blob/master/ami_spec.gemspec#L26)

[net-ssh]: https://rubygems.org/gems/net-ssh
[changelog]: https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt