### PR TITLE
Generate temporary security groups in AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Options:
   -i, --aws-instance-type=<s>           The ec2 instance type, defaults to t2.micro (default:
                                         t2.micro)
   -c, --aws-security-groups=<s>         Security groups to associate to the launched instances. May be
-                                        specified multiple times
+                                        specified multiple times. If not provided a temporary security
+                                        group will be generated in AWS
   -p, --aws-public-ip                   Launch instances with a public IP
   -t, --ssh-retries=<i>                 The number of times we should try sshing to the ec2 instance
                                         before giving up. Defaults to 30 (default: 30)

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -59,8 +59,8 @@ module AmiSpec
     end
 
     if options[:aws_security_groups].nil? || options[:aws_security_groups].empty?
-      security_group = AwsSecurityGroup.create(ec2: ec2, subnet_id: options[:subnet_id], logger: logger)
-      options[:aws_security_groups] = [security_group.group_id]
+      temporary_security_group = AwsSecurityGroup.create(ec2: ec2, subnet_id: options[:subnet_id], logger: logger)
+      options[:aws_security_groups] = [temporary_security_group.group_id]
     end
 
     instances = []
@@ -83,7 +83,7 @@ module AmiSpec
   ensure
     stop_instances(instances, options[:debug])
     key_pair.delete if key_pair
-    security_group.delete if security_group
+    temporary_security_group.delete if temporary_security_group
   end
 
   def self.stop_instances(instances, debug)

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -31,6 +31,8 @@ module AmiSpec
   # aws_security_group_ids::
   #   AWS Security groups to assign to the instances
   #   If not provided a temporary security group will be generated in AWS
+  # allow_any_temporary_security_group::
+  #   The temporary security group will allow SSH connections from any IP address (0.0.0.0/0)
   # aws_instance_type::
   #   AWS ec2 instance type
   # aws_public_ip::
@@ -59,7 +61,12 @@ module AmiSpec
     end
 
     if options[:aws_security_groups].nil? || options[:aws_security_groups].empty?
-      temporary_security_group = AwsSecurityGroup.create(ec2: ec2, subnet_id: options[:subnet_id], logger: logger)
+      temporary_security_group = AwsSecurityGroup.create(
+        ec2: ec2,
+        subnet_id: options[:subnet_id],
+        allow_any_ip: options[:allow_any_temporary_security_group],
+        logger: logger
+      )
       options[:aws_security_groups] = [temporary_security_group.group_id]
     end
 
@@ -118,6 +125,7 @@ module AmiSpec
       opt :aws_instance_type, "The ec2 instance type, defaults to t2.micro", type: :string, default: 't2.micro'
       opt :aws_security_groups, "Security groups to associate to the launched instances. May be specified multiple times. If not provided a temporary security group will be generated in AWS",
           type: :string, default: nil, multi: true
+      opt :allow_any_temporary_security_group, "The temporary security group will allow SSH connections from any IP address (0.0.0.0/0)"
       opt :aws_public_ip, "Launch instances with a public IP"
       opt :ssh_retries, "The number of times we should try sshing to the ec2 instance before giving up. Defaults to 30",
           type: :int, default: 30

--- a/lib/ami_spec/aws_instance.rb
+++ b/lib/ami_spec/aws_instance.rb
@@ -26,7 +26,7 @@ module AmiSpec
       @iam_instance_profile_arn = options.fetch(:iam_instance_profile_arn, nil)
     end
 
-    def_delegators :@instance, :instance_id, :tags, :terminate, :private_ip_address, :public_ip_address
+    def_delegators :@instance, :instance_id, :tags, :private_ip_address, :public_ip_address
 
     def start
       client = Aws::EC2::Client.new(client_options)
@@ -35,6 +35,11 @@ module AmiSpec
       @instance = Aws::EC2::Instance.new(placeholder_instance.instance_id, client_options)
       @instance.wait_until_running
       tag_instance
+    end
+
+    def terminate
+      @instance.terminate
+      @instance.wait_until_terminated
     end
 
     private

--- a/lib/ami_spec/aws_security_group.rb
+++ b/lib/ami_spec/aws_security_group.rb
@@ -13,13 +13,11 @@ module AmiSpec
     def initialize(ec2: Aws::EC2::Resource.new,
                    group_name_prefix: "ami-spec-",
                    connection_port: 22,
-                   vpc_id: nil,
-                   subnet_id: nil,
+                   subnet_id:,
                    logger: Logger.new(STDOUT))
       @ec2 = ec2
       @group_name = "#{group_name_prefix}#{SecureRandom.uuid}"
       @connection_port = connection_port
-      @vpc_id = vpc_id
       @subnet_id = subnet_id
       @logger = logger
     end

--- a/lib/ami_spec/aws_security_group.rb
+++ b/lib/ami_spec/aws_security_group.rb
@@ -1,0 +1,68 @@
+require 'aws-sdk-ec2'
+require 'forwardable'
+require 'securerandom'
+
+module AmiSpec
+  class AwsSecurityGroup
+    extend Forwardable
+
+    def self.create(**args)
+      new(**args).tap(&:create)
+    end
+
+    def initialize(ec2: Aws::EC2::Resource.new,
+                   group_name_prefix: "ami-spec-",
+                   connection_port: 22,
+                   vpc_id: nil,
+                   subnet_id: nil,
+                   logger: Logger.new(STDOUT))
+      @ec2 = ec2
+      @group_name = "#{group_name_prefix}#{SecureRandom.uuid}"
+      @connection_port = connection_port
+      @vpc_id = vpc_id
+      @subnet_id = subnet_id
+      @logger = logger
+    end
+
+    def_delegators :@security_group, :group_id
+    attr_reader :group_name
+
+    def create
+      @logger.info "Creating temporary AWS security group: #{@group_name}"
+      create_security_group
+      allow_ingress_via_connection_port
+    end
+
+    def delete
+      @logger.info "Deleting temporary AWS security group: #{@group_name}"
+      @security_group.delete
+    end
+
+    private
+
+    def create_security_group
+      @security_group = @ec2.create_security_group(
+        group_name: @group_name,
+        description: "A temporary security group for running AmiSpec",
+        vpc_id: vpc_id,
+      )
+    end
+
+    def allow_ingress_via_connection_port
+      @security_group.authorize_ingress(
+        ip_permissions: [
+          {
+            ip_protocol: "tcp",
+            from_port: @connection_port,
+            to_port: @connection_port,
+            ip_ranges: [{cidr_ip: "0.0.0.0/0"}],
+          },
+        ],
+      )
+    end
+
+    def vpc_id
+      @vpc_id ||= @ec2.subnet(@subnet_id).vpc_id
+    end
+  end
+end

--- a/spec/ami_spec/aws_security_group_spec.rb
+++ b/spec/ami_spec/aws_security_group_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe AmiSpec::AwsSecurityGroup do
+  subject(:aws_security_group) { described_class.create(ec2: ec2, subnet_id: test_subnet_id, logger: logger) }
+
+  let(:ec2) { instance_spy(Aws::EC2::Resource, create_security_group: security_group, subnet: subnet) }
+  let(:security_group) { instance_spy(Aws::EC2::SecurityGroup, group_id: test_group_id) }
+  let(:subnet) { instance_spy(Aws::EC2::Subnet, vpc_id: test_vpc_id) }
+  let(:test_subnet_id) { 'test-subnet-id' }
+  let(:test_group_id) { 'test-group-id' }
+  let(:test_vpc_id) { 'test-vpc-id' }
+  let(:logger) { instance_spy(Logger) }
+
+  describe '#create' do
+    subject(:create) { aws_security_group }
+
+    it 'creates the security group in AWS' do
+      create
+      expect(ec2).to have_received(:create_security_group).with(group_name: aws_security_group.group_name, vpc_id: test_vpc_id, description: anything)
+    end
+
+    it 'adds the ingress rule for SSH' do
+      create
+      expect(security_group).to have_received(:authorize_ingress).with(
+        ip_permissions: [{ip_protocol: "tcp", from_port: 22, to_port: 22, ip_ranges: [{cidr_ip: "0.0.0.0/0"}]}]
+      )
+    end
+
+    it 'loads the subnet to find the vpc id' do
+      create
+      expect(ec2).to have_received(:subnet).with(test_subnet_id)
+    end
+
+    it 'logs the creation of the key pair in AWS' do
+      create
+      expect(logger).to have_received(:info).with "Creating temporary AWS security group: #{aws_security_group.group_name}"
+    end
+  end
+
+  describe '#group_name' do
+    subject(:key_name) { aws_security_group.group_name }
+
+    it { should start_with('ami-spec-') }
+  end
+
+  describe '#group_id' do
+    subject(:group_id) { aws_security_group.group_id }
+
+    it 'is obtained from the AWS create-security-group API response' do
+      expect(group_id).to eq test_group_id
+    end
+  end
+
+  describe '#delete' do
+    subject(:delete) { aws_security_group.delete }
+
+    it 'deletes the security group in AWS' do
+      delete
+      expect(security_group).to have_received(:delete)
+    end
+
+    it 'logs the deletion of the key pair in AWS' do
+      delete
+      expect(logger).to have_received(:info).with "Deleting temporary AWS security group: #{aws_security_group.group_name}"
+    end
+  end
+end
+

--- a/spec/ami_spec_spec.rb
+++ b/spec/ami_spec_spec.rb
@@ -5,10 +5,12 @@ describe AmiSpec do
   let(:ec2) { instance_spy(Aws::EC2::Resource) }
   let(:ec2_double) { instance_double(AmiSpec::AwsInstance) }
   let(:aws_key_pair) { instance_spy(AmiSpec::AwsKeyPair) }
+  let(:aws_security_group) { instance_spy(AmiSpec::AwsSecurityGroup) }
   let(:state) { double(name: 'running') }
   let(:test_result) { true }
   let(:server_spec_double) { double(run: test_result) }
   let(:key_name) { 'key' }
+  let(:security_groups) { ['sg-1234'] }
   subject do
     described_class.run(
       amis: amis,
@@ -21,6 +23,7 @@ describe AmiSpec do
       ssh_user: 'ubuntu',
       debug: false,
       ssh_retries: 30,
+      aws_security_groups: security_groups,
     )
   end
 
@@ -37,6 +40,7 @@ describe AmiSpec do
       allow(AmiSpec::AwsInstance).to receive(:start).and_return(ec2_double)
       allow(AmiSpec::ServerSpec).to receive(:new).and_return(server_spec_double)
       allow(AmiSpec::AwsKeyPair).to receive(:create).and_return(aws_key_pair)
+      allow(AmiSpec::AwsSecurityGroup).to receive(:create).and_return(aws_security_group)
       allow(Aws::EC2::Resource).to receive(:new).and_return(ec2)
       allow(ec2_double).to receive(:terminate).and_return(true)
       allow(ec2_double).to receive(:private_ip_address).and_return('127.0.0.1')
@@ -83,6 +87,29 @@ describe AmiSpec do
       it 'does not create a key pair' do
         subject
         expect(AmiSpec::AwsKeyPair).not_to have_received(:create)
+      end
+    end
+
+    context 'given a security group id is not provided' do
+      let(:security_groups) { [] }
+
+      it 'creates a temporary security group' do
+        subject
+        expect(AmiSpec::AwsSecurityGroup).to have_received(:create)
+      end
+
+      it 'deletes the temporary security group' do
+        subject
+        expect(aws_security_group).to have_received(:delete)
+      end
+    end
+
+    context 'given a security group id is provided' do
+      let(:security_groups) { ['sg-4321'] }
+
+      it 'does not create a temporary security group' do
+        subject
+        expect(AmiSpec::AwsSecurityGroup).not_to have_received(:create)
       end
     end
   end

--- a/spec/ami_spec_spec.rb
+++ b/spec/ami_spec_spec.rb
@@ -11,11 +11,13 @@ describe AmiSpec do
   let(:server_spec_double) { double(run: test_result) }
   let(:key_name) { 'key' }
   let(:security_groups) { ['sg-1234'] }
+  let(:subnet_id) { 'subnet-1234abcd' }
+  let(:allow_any_temporary_security_group) { false }
   subject do
     described_class.run(
       amis: amis,
       specs: '/tmp/foobar',
-      subnet_id: 'subnet-1234abcd',
+      subnet_id: subnet_id,
       key_name: key_name,
       key_file: 'key.pem',
       aws_public_ip: false,
@@ -24,6 +26,7 @@ describe AmiSpec do
       debug: false,
       ssh_retries: 30,
       aws_security_groups: security_groups,
+      allow_any_temporary_security_group: allow_any_temporary_security_group,
     )
   end
 
@@ -96,6 +99,32 @@ describe AmiSpec do
       it 'creates a temporary security group' do
         subject
         expect(AmiSpec::AwsSecurityGroup).to have_received(:create)
+      end
+
+      it 'passes the subnet id' do
+        subject
+        expect(AmiSpec::AwsSecurityGroup).to have_received(:create)
+          .with(a_hash_including(subnet_id: subnet_id))
+      end
+
+      context 'given allow_any_temporary_security_group: true' do
+        let(:allow_any_temporary_security_group) { true }
+
+        it 'passes allow_any_ip: true' do
+          subject
+          expect(AmiSpec::AwsSecurityGroup).to have_received(:create)
+            .with(a_hash_including(allow_any_ip: true))
+        end
+      end
+
+      context 'given allow_any_temporary_security_group: false' do
+        let(:allow_any_temporary_security_group) { false }
+
+        it 'passes allow_any_ip: true' do
+          subject
+          expect(AmiSpec::AwsSecurityGroup).to have_received(:create)
+            .with(a_hash_including(allow_any_ip: false))
+        end
       end
 
       it 'deletes the temporary security group' do

--- a/spec/aws_instance_spec.rb
+++ b/spec/aws_instance_spec.rb
@@ -6,9 +6,9 @@ describe AmiSpec::AwsInstance do
   let(:role) { 'web_server' }
   let(:sec_group_id) { nil }
   let(:region) { nil }
-  let(:client_double) { instance_double(Aws::EC2::Client) }
-  let(:new_ec2_double) { instance_double(Aws::EC2::Types::Instance) }
-  let(:ec2_double) { instance_double(Aws::EC2::Instance) }
+  let(:client_double) { instance_spy(Aws::EC2::Client) }
+  let(:new_ec2_double) { instance_spy(Aws::EC2::Types::Instance) }
+  let(:ec2_double) { instance_spy(Aws::EC2::Instance) }
   let(:tags) { {} }
   let(:iam_instance_profile_arn) { nil }
   let(:user_data_file) { nil }
@@ -34,9 +34,6 @@ describe AmiSpec::AwsInstance do
     allow(client_double).to receive(:run_instances).and_return(double(instances: [new_ec2_double]))
     allow(ec2_double).to receive(:create_tags).and_return(double)
     allow(Aws::EC2::Instance).to receive(:new).and_return(ec2_double)
-    allow(new_ec2_double).to receive(:instance_id)
-    allow(ec2_double).to receive(:instance_id)
-    allow(ec2_double).to receive(:wait_until_running)
   end
 
   describe '#start' do
@@ -139,4 +136,19 @@ describe AmiSpec::AwsInstance do
     end
   end
 
+  describe '#terminate' do
+    subject(:terminate) { aws_instance.terminate }
+
+    before { aws_instance.start }
+
+    it 'instructs the EC2 instance to terminate' do
+      terminate
+      expect(ec2_double).to have_received(:terminate)
+    end
+
+    it 'waits for the EC2 instance to terminate' do
+      terminate
+      expect(ec2_double).to have_received(:wait_until_terminated)
+    end
+  end
 end


### PR DESCRIPTION
It can be rather cumbersome to manage security groups. Especially if you have a build creating and testing AMI across multiple AWS accounts and regions. You have to add them in AWS and then ensure the correct one is being used in CI servers.

Instead of all that manual work, let's get AMI Spec to do it for us!

I propose that if a security group isn't provided via the command line, then a temporary security group is generated in AWS and used for the duration of the testing. This temporary security group allows SSH access. After the tests have completed and the EC2 instance is terminated, the security group is deleted.