### PR TITLE
Only package what's required into the gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Gemfile.lock
+pkg/
 *.gem
 .ruby-version
 spec/examples.txt

--- a/ami_spec.gemspec
+++ b/ami_spec.gemspec
@@ -12,9 +12,10 @@ Gem::Specification.new do |gem|
   gem.summary       = gem.description
   gem.homepage      = 'https://github.com/envato/ami-spec'
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files -z`.split("\x0").select do |f|
+    f.match(%r{^(?:README|LICENSE|CHANGELOG|lib/|bin/)})
+  end
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
   gem.add_dependency 'aws-sdk-ec2', '~> 1'


### PR DESCRIPTION
The various dotfiles and tests in the repository don't need to be included. Let's keep the file size down. This reduces the gem size from 20K down to 13K.

#### Considerations

I don't think people generally run tests for installed gems. I have never done it.