### PR TITLE
Use a default VPC subnet, if subnet_id is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Options:
   -o, --role-ami-file=<s>               A file containing comma separated roles and amis. i.e.
                                         web_server,ami-id.
   -s, --specs=<s>                       The directory to find ServerSpecs
-  -u, --subnet-id=<s>                   The subnet to start the instance in
+  -u, --subnet-id=<s>                   The subnet to start the instance in. If not provided a subnet
+                                        will be chosen from the default VPC
   -k, --key-name=<s>                    The SSH key name to assign to instances. If not provided a
                                         temporary key pair will be generated in AWS
   -e, --key-file=<s>                    The SSH private key file associated to the key_name

--- a/lib/ami_spec/aws_default_vpc.rb
+++ b/lib/ami_spec/aws_default_vpc.rb
@@ -1,0 +1,10 @@
+require 'aws-sdk-ec2'
+
+module AmiSpec
+  class AwsDefaultVpc
+    def self.find_subnet(ec2: Aws::EC2::Resource.new)
+      default_vpc = ec2.vpcs(filters: [{name: 'isDefault', values: ['true']}]).first
+      default_vpc && default_vpc.subnets.first
+    end
+  end
+end

--- a/spec/ami_spec/aws_default_vpc_spec.rb
+++ b/spec/ami_spec/aws_default_vpc_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe AmiSpec::AwsDefaultVpc do
+  subject(:aws_default_vpc) { described_class.create(ec2: ec2, logger: logger) }
+
+  let(:ec2) { instance_spy(Aws::EC2::Resource, vpcs: vpcs) }
+
+  describe '#find_subnet' do
+    subject(:find_subnet) { described_class.find_subnet(ec2: ec2) }
+
+    context 'given no default vpc' do
+      let(:vpcs) { instance_spy(Aws::EC2::Vpc::Collection, first: nil) }
+
+      it 'returns nil' do
+        expect(find_subnet).to be_nil
+      end
+    end
+
+    context 'given a default vpc' do
+      let(:vpcs) { instance_spy(Aws::EC2::Vpc::Collection, first: default_vpc) }
+      let(:default_vpc) { instance_spy(Aws::EC2::Vpc, subnets: subnets) }
+
+      context 'given the default vpc has no subnets' do
+        let(:subnets) { instance_spy(Aws::EC2::Subnet::Collection, first: nil) }
+
+        it 'returns nil' do
+          expect(find_subnet).to be_nil
+        end
+      end
+
+      context 'given the default vpc has a subnet' do
+        let(:subnets) { instance_spy(Aws::EC2::Subnet::Collection, first: subnet) }
+        let(:subnet) { instance_spy(Aws::EC2::Subnet) }
+
+        it 'returns the subnet' do
+          expect(find_subnet).to eq(subnet)
+        end
+      end
+    end
+  end
+end

--- a/spec/ami_spec_spec.rb
+++ b/spec/ami_spec_spec.rb
@@ -148,7 +148,8 @@ RSpec.describe AmiSpec do
       it 'launches the EC2 instances in the provided subnet' do
         subject
         expect(AmiSpec::AwsInstance).to have_received(:start).twice.with(
-          an_object_having_attributes(subnet_id: subnet_id))
+          an_instance_of(AmiSpec::AwsInstanceOptions)
+            .and(having_attributes(subnet_id: subnet_id)))
       end
     end
 
@@ -165,7 +166,8 @@ RSpec.describe AmiSpec do
         it 'launches the EC2 instances in the default VPC subnet' do
           subject
           expect(AmiSpec::AwsInstance).to have_received(:start).twice.with(
-            an_object_having_attributes(subnet_id: default_subnet_id))
+            an_instance_of(AmiSpec::AwsInstanceOptions)
+              .and(having_attributes(subnet_id: default_subnet_id)))
         end
 
         it 'logs which subnet is being used' do

--- a/spec/ami_spec_spec.rb
+++ b/spec/ami_spec_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe AmiSpec do
   let(:ec2_double) { instance_double(AmiSpec::AwsInstance) }
   let(:aws_key_pair) { instance_spy(AmiSpec::AwsKeyPair) }
   let(:aws_security_group) { instance_spy(AmiSpec::AwsSecurityGroup) }
+  let(:logger) { instance_spy(Logger) }
   let(:state) { double(name: 'running') }
   let(:test_result) { true }
   let(:server_spec_double) { double(run: test_result) }
@@ -48,6 +49,7 @@ RSpec.describe AmiSpec do
       allow(ec2_double).to receive(:terminate).and_return(true)
       allow(ec2_double).to receive(:private_ip_address).and_return('127.0.0.1')
       allow_any_instance_of(Object).to receive(:sleep)
+      allow(Logger).to receive(:new).and_return(logger)
     end
 
     context 'successful tests' do
@@ -139,6 +141,59 @@ RSpec.describe AmiSpec do
       it 'does not create a temporary security group' do
         subject
         expect(AmiSpec::AwsSecurityGroup).not_to have_received(:create)
+      end
+    end
+
+    context 'given a subnet id is provided' do
+      it 'launches the EC2 instances in the provided subnet' do
+        subject
+        expect(AmiSpec::AwsInstance).to have_received(:start).twice.with(
+          an_object_having_attributes(subnet_id: subnet_id))
+      end
+    end
+
+    context 'given a subnet id is not provided' do
+      let(:subnet_id) { nil }
+
+      context 'given a default VPC subnet is found' do
+        let(:default_subnet) { instance_spy(Aws::EC2::Subnet, id: default_subnet_id) }
+        let(:default_subnet_id) { 'subnet-1234' }
+        before do
+          allow(AmiSpec::AwsDefaultVpc).to receive(:find_subnet).and_return(default_subnet)
+        end
+
+        it 'launches the EC2 instances in the default VPC subnet' do
+          subject
+          expect(AmiSpec::AwsInstance).to have_received(:start).twice.with(
+            an_object_having_attributes(subnet_id: default_subnet_id))
+        end
+
+        it 'logs which subnet is being used' do
+          subject
+          expect(logger).to have_received(:info).with(
+            "Using subnet #{default_subnet_id} from the default VPC"
+          )
+        end
+
+        context 'given a security group id is not provided' do
+          let(:security_groups) { [] }
+
+          it 'creates the temporary security group in the default VPC subnet' do
+            subject
+            expect(AmiSpec::AwsSecurityGroup).to have_received(:create)
+              .with(a_hash_including(subnet_id: default_subnet_id))
+          end
+        end
+      end
+
+      context 'given a default VPC subnet is not found' do
+        before do
+          allow(AmiSpec::AwsDefaultVpc).to receive(:find_subnet).and_return(nil)
+        end
+
+        it 'raises an error, asking for a subnet_id to be provided' do
+          expect { subject }.to raise_error('No default VPC subnet found. Please specify a subnet id.')
+        end
       end
     end
   end


### PR DESCRIPTION
For extra convenience, how about we use a subnet from the default VPC (if one exists).

This changes the `--subnet-id` command line option from required to optional.