### PR TITLE
Wait for command

### DIFF
--- a/lib/ami_spec/version.rb
+++ b/lib/ami_spec/version.rb
@@ -1,3 +1,3 @@
 module AmiSpec
-  VERSION = '1.5.0'
+  VERSION = '1.6.0'
 end

--- a/lib/ami_spec/wait_for_cloud_init.rb
+++ b/lib/ami_spec/wait_for_cloud_init.rb
@@ -4,7 +4,7 @@ module AmiSpec
   class WaitForCloudInit
     def self.wait(ip_address, user, key, port=22)
       Net::SSH.start(ip_address, user, keys: [key], :verify_host_key => :never, port: port) do |ssh|
-        ssh.exec '/usr/bin/cloud-init status --wait'
+        ssh.exec! '/usr/bin/cloud-init status --wait'
       end
     end
   end


### PR DESCRIPTION
`ssh.exec` runs a command but doesn't wait for it to complete. That made this feature ineffective.

Use `ssh.exec!`. Arguably `ssh.exec` should wait and `exec!` should not wait, since that's surprising, but who am I to argue with the creators of net/ssh.