### PR TITLE
Run CI on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+---
+name: tests
+on: [ push, pull_request ]
+jobs:
+  test:
+    name: Test (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: RSpec
+        run: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
- - 2.2.6
- - 2.4.4
- - 2.5.1
- - 2.6.1
-script: bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/envato/ami-spec/blob/master/LICENSE.txt)
 [![Gem Version](https://badge.fury.io/rb/ami_spec.svg)](https://badge.fury.io/rb/ami_spec)
-[![Build Status](https://travis-ci.org/envato/ami-spec.svg?branch=master)](https://travis-ci.org/envato/ami-spec)
+[![Build Status](https://github.com/envato/ami-spec/workflows/tests/badge.svg?branch=master)](https://github.com/envato/ami-spec/actions?query=branch%3Amaster+workflow%3Atests)
 
 Acceptance testing your AMIs.
 


### PR DESCRIPTION
Migrate from Travis CI to [GitHub Actions](https://github.com/features/actions) for the CI build.