### PR TITLE
Add Net::SSH::Exception to list of caught SSH errors

### DIFF
--- a/lib/ami_spec/wait_for_ssh.rb
+++ b/lib/ami_spec/wait_for_ssh.rb
@@ -9,7 +9,7 @@ module AmiSpec
       while retries < max_retries
         begin
           Net::SSH.start(ip_address, user, keys: [key], :verify_host_key => :never) { |ssh| ssh.exec 'echo boo!' }
-        rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, Timeout::Error => error
+        rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, Timeout::Error, Net::SSH::Exception => error
           last_error = error
           sleep 1
         else

--- a/spec/wait_for_ssh_spec.rb
+++ b/spec/wait_for_ssh_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AmiSpec::WaitForSSH do
       end
 
       it 'returns the last error' do
-        expect(Net::SSH).to receive(:start).and_raise(Errno::ECONNREFUSED, 'some other error')
+        expect(Net::SSH).to receive(:start).and_raise(Net::SSH::ConnectionTimeout, 'some other error')
         expect{subject}.to raise_error(AmiSpec::InstanceConnectionTimeout, /ssh failed/)
       end
 


### PR DESCRIPTION
Based on issue #50 , I added `Net::SSH::Exception` to the list of caught errors in `WaitForSSH`. I've been having the same issues when running ami_spec in CodeBuild, where no matter what I set the retries to, it would intermittently error out with a `Net::SSH::ConnectionTimeout` error. I updated the test to check for this kind of error in addition to the `Errno::ECONNREFUSED` error.