### PR TITLE
Add public IP flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Options:
                                             group will be generated in AWS
   -n, --allow-any-temporary-security-group  The temporary security group will allow SSH connections 
                                             from any IP address (0.0.0.0/0), otherwise allow the subnet's block
-  -p, --aws-public-ip                       Launch instances with a public IP
+  -p, --aws-public-ip                       Launch instances with a public IP and use that IP for SSH
+  -q, --associate-public-ip                 Launch instances with a public IP but don't use that IP for SSH
   -t, --ssh-retries=<i>                     The number of times we should try sshing to the ec2 instance
                                             before giving up. Defaults to 30 (default: 30)
   -g, --tags=<s>                            Additional tags to add to launched instances in the form of

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Options:
   -n, --allow-any-temporary-security-group  The temporary security group will allow SSH connections 
                                             from any IP address (0.0.0.0/0), otherwise allow the subnet's block
   -p, --aws-public-ip                       Launch instances with a public IP and use that IP for SSH
-  -q, --associate-public-ip                 Launch instances with a public IP but don't use that IP for SSH
+  -q, --associate-public-ip                 Launch instances with a public IP and use the Private IP for SSH
   -t, --ssh-retries=<i>                     The number of times we should try sshing to the ec2 instance
                                             before giving up. Defaults to 30 (default: 30)
   -g, --tags=<s>                            Additional tags to add to launched instances in the form of

--- a/lib/ami_spec.rb
+++ b/lib/ami_spec.rb
@@ -148,6 +148,7 @@ web_server,ami-id.',
       opt :allow_any_temporary_security_group, 'The temporary security group will allow SSH connections from any IP address (0.0.0.0/0)',
           short: :n
       opt :aws_public_ip, 'Launch instances with a public IP', short: :p
+      opt :associate_public_ip, "Launch instances with a public IP but don't use that IP for SSH", short: :q
       opt :ssh_retries, 'The number of times we should try sshing to the ec2 instance before giving up. Defaults to 30',
           type: :int, default: 30, short: :t
       opt :tags, 'Additional tags to add to launched instances in the form of comma separated key=value pairs. i.e. Name=AmiSpec',

--- a/lib/ami_spec/aws_instance.rb
+++ b/lib/ami_spec/aws_instance.rb
@@ -19,6 +19,7 @@ module AmiSpec
       @key_name = options.fetch(:key_name)
       @instance_type = options.fetch(:aws_instance_type)
       @public_ip = options.fetch(:aws_public_ip)
+      @associate_public_ip = options.fetch(:associate_public_ip)
       @region = options.fetch(:aws_region)
       @security_group_ids = options.fetch(:aws_security_groups)
       @tags = ec2ify_tags(options.fetch(:tags))
@@ -61,7 +62,7 @@ module AmiSpec
         key_name: @key_name,
         network_interfaces: [{
           device_index: 0,
-          associate_public_ip_address: @public_ip,
+          associate_public_ip_address: @public_ip || @associate_public_ip,
           subnet_id: @subnet_id,
         }]
       }

--- a/lib/ami_spec/aws_instance_options.rb
+++ b/lib/ami_spec/aws_instance_options.rb
@@ -12,6 +12,7 @@ module AmiSpec
     property :aws_public_ip
     property :aws_region
     property :aws_security_groups
+    property :associate_public_ip
     property :tags
     property :user_data_file
     property :iam_instance_profile_arn

--- a/lib/ami_spec/version.rb
+++ b/lib/ami_spec/version.rb
@@ -1,3 +1,3 @@
 module AmiSpec
-  VERSION = '1.7.0'
+  VERSION = '1.8.0'
 end

--- a/spec/aws_instance_spec.rb
+++ b/spec/aws_instance_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe AmiSpec::AwsInstance do
   let(:tags) { {} }
   let(:iam_instance_profile_arn) { nil }
   let(:user_data_file) { nil }
+  let(:aws_public_ip) { false }
+  let(:associate_public_ip) { false }
 
   subject(:aws_instance) do
     described_class.new(
@@ -19,7 +21,8 @@ RSpec.describe AmiSpec::AwsInstance do
       subnet_id: 'subnet',
       key_name: 'key',
       aws_instance_type: 't2.micro',
-      aws_public_ip: false,
+      aws_public_ip: aws_public_ip,
+      associate_public_ip: associate_public_ip,
       aws_security_groups: sec_group_id,
       aws_region: region,
       tags: tags,
@@ -116,6 +119,42 @@ RSpec.describe AmiSpec::AwsInstance do
       it 'does include iam_instance_profile_arn' do
         expect(client_double).to receive(:run_instances).with(
             hash_including(:iam_instance_profile =>  { arn: 'my_arn'})
+        )
+        start
+      end
+    end
+
+    context 'with aws_public_ip' do
+      let(:aws_public_ip) { true }
+      it 'sets associate public IP' do
+        expect(client_double).to receive(:run_instances).with(
+          hash_including(
+            network_interfaces: [
+              {
+                device_index: 0,
+                associate_public_ip_address: true,
+                subnet_id: 'subnet'
+              }
+            ]
+          )
+        )
+        start
+      end
+    end
+
+    context 'with associate_public_ip' do
+      let(:associate_public_ip) { true }
+      it 'sets associate public IP' do
+        expect(client_double).to receive(:run_instances).with(
+          hash_including(
+            network_interfaces: [
+              {
+                device_index: 0,
+                associate_public_ip_address: true,
+                subnet_id: 'subnet'
+              }
+            ]
+          )
         )
         start
       end


### PR DESCRIPTION
This allows us to boot an instance that can talk to the internet while still using the private IP for SSH