### PR TITLE
Resolve error when `--user-data-file` option not provided

### DIFF
--- a/lib/ami_spec/server_spec.rb
+++ b/lib/ami_spec/server_spec.rb
@@ -16,8 +16,6 @@ module AmiSpec
       @user = options.fetch(:ssh_user)
       @key_file = options.fetch(:key_file)
       @buildkite = options.fetch(:buildkite)
-      @user_data_file = options.fetch(:user_data_file)
-      @iam_instance_profile_arn = options.fetch(:user_data_file)
     end
 
     def run

--- a/lib/ami_spec/server_spec_options.rb
+++ b/lib/ami_spec/server_spec_options.rb
@@ -11,7 +11,5 @@ module AmiSpec
     property :specs
     property :ssh_user
     property :buildkite
-    property :user_data_file
-    property :iam_instance_profile_arn
   end
 end


### PR DESCRIPTION
### Context

On later versions of ami_spec, there is an error when running the tool without the `--user-data-file` option:

```
Creating temporary AWS key pair: ami-spec-bd8f8b3e-7de4-4ddf-a631-757b7b03c67c
Creating AWS EC2 instance for ami-0cecf2bc129560938
Waiting for AWS EC2 instance to start: i-0b0c93b51604615b3
AWS EC2 instance started: i-0b0c93b51604615b3
Waiting for SSH…
Waiting for cloud init…
Running serverspec…
Terminating AWS EC2 instance: i-0b0c93b51604615b3
AWS EC2 instance terminated: i-0b0c93b51604615b3
Deleting temporary AWS key pair: ami-spec-bd8f8b3e-7de4-4ddf-a631-757b7b03c67c
bundler: failed to load command: ami_spec (/usr/local/bundle/bin/ami_spec)
/usr/local/bundle/bundler/gems/ami-spec-48b6eb410a60/lib/ami_spec/server_spec.rb:19:in `fetch': key not found: :user_data_file (KeyError)
	from /usr/local/bundle/bundler/gems/ami-spec-48b6eb410a60/lib/ami_spec/server_spec.rb:19:in `initialize'
	from /usr/local/bundle/bundler/gems/ami-spec-48b6eb410a60/lib/ami_spec.rb:106:in `new'
	from /usr/local/bundle/bundler/gems/ami-spec-48b6eb410a60/lib/ami_spec.rb:106:in `block in run'
	from /usr/local/bundle/bundler/gems/ami-spec-48b6eb410a60/lib/ami_spec.rb:91:in `each'
	from /usr/local/bundle/bundler/gems/ami-spec-48b6eb410a60/lib/ami_spec.rb:91:in `run'
	from /usr/local/bundle/bundler/gems/ami-spec-48b6eb410a60/lib/ami_spec.rb:202:in `invoke'
	from /usr/local/bundle/bundler/gems/ami-spec-48b6eb410a60/bin/ami_spec:5:in `<top (required)>'
	from /usr/local/bundle/bin/ami_spec:25:in `load'
	from /usr/local/bundle/bin/ami_spec:25:in `<top (required)>'
	from /usr/local/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
	from /usr/local/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
	from /usr/local/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
	from /usr/local/lib/ruby/3.2.0/bundler/cli.rb:491:in `exec'
	from /usr/local/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /usr/local/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /usr/local/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /usr/local/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
	from /usr/local/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /usr/local/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
	from /usr/local/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/libexec/bundle:45:in `block in <top (required)>'
	from /usr/local/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /usr/local/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/libexec/bundle:33:in `<top (required)>'
	from /usr/local/bin/bundle:25:in `load'
	from /usr/local/bin/bundle:25:in `<main>'
```

### Change

Resolve this problem with a fix to the `ServerSpec` class. This class does not use the `iam_instance_profile_arn` or `user_data_file` properties, so avoid fetching them from the options.