### PR TITLE
CI: add Ruby 2.7, 3.0, 3.1, and 3.2 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6' ]
+        ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'rake'
+gem 'rexml'

--- a/ami_spec.gemspec
+++ b/ami_spec.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'aws-sdk-ec2', '~> 1'
-  gem.add_development_dependency 'rake'
   gem.add_dependency 'serverspec', '~> 2'
   gem.add_dependency 'specinfra', '>= 2.45'
   gem.add_dependency 'optimist', '~> 3'


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it and other Ruby versions to the build matrix for confidence in compatibility.