### PR TITLE
Unpin `net-ssh`: allow versions 5 and up

### DIFF
--- a/ami_spec.gemspec
+++ b/ami_spec.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'specinfra', '>= 2.45'
   gem.add_dependency 'optimist', '~> 3'
   gem.add_dependency 'hashie'
-  gem.add_dependency 'net-ssh', '~> 5'
+  gem.add_dependency 'net-ssh', '>= 5'
 
   gem.required_ruby_version = '>= 2.2.6'
 end


### PR DESCRIPTION
There have been a few major releases of the [`net-ssh`](https://github.com/net-ssh/net-ssh) library. These seem compatible with ami_spec. Let's loosen the dependency constraint to allow `net-ssh` version 5 and greater.