### PR TITLE
CI: add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
+        ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
Ruby 3.3 has [been released](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)! Let's add it to the CI build matrix for confidence in compatibility.

Also, remove Ruby 2.2 from the CI build matrix. This super old version of Ruby is now segfaulting on GitHub Actions.