### PR TITLE
CI: add Ruby 3.4 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
+        ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
Ruby 3.4 has been released! :tada:
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/

Let's add it to the CI build matrix to ensure compatibility.